### PR TITLE
Fix Brave Search API implementation

### DIFF
--- a/daily-brief-bot/src/modules/brave_search.py
+++ b/daily-brief-bot/src/modules/brave_search.py
@@ -1,19 +1,22 @@
 import requests
+import json
 
 class BraveSearch:
     def __init__(self, api_key):
         self.api_key = api_key
-        self.base_url = 'https://api.search.brave.com/v1/news'
+        self.base_url = 'https://api.search.brave.com/v1/search'  # Changed to search endpoint
         self.headers = {
             'Accept': 'application/json',
-            'X-Brave-API-Key': api_key
+            'X-Brave-API-Key': api_key  # Using correct header name
         }
     
     def search(self, query, count=5):
         """Search news using Brave Search API"""
         params = {
             'q': query,
-            'count': count
+            'count': count,
+            'type': 'news',  # Specify news search
+            'freshness': 'day'  # Get recent news only
         }
         
         try:
@@ -22,8 +25,26 @@ class BraveSearch:
                 headers=self.headers,
                 params=params
             )
+            
+            # Print request details for debugging
+            print(f'Request URL: {response.url}')
+            print(f'Request headers: {json.dumps(self.headers)}')
+            
             response.raise_for_status()
-            return response.json()
+            data = response.json()
+            
+            # Extract and format news items
+            if 'news' in data:
+                return data['news']
+            elif 'webPages' in data:  # Fallback to web results if no news
+                return data['webPages']['value']
+            return []
+            
         except requests.RequestException as e:
             print(f'Error in Brave Search: {e}')
-            return None
+            if hasattr(e.response, 'text'):
+                print(f'Response content: {e.response.text}')
+            return []
+        except Exception as e:
+            print(f'Unexpected error in Brave Search: {e}')
+            return []


### PR DESCRIPTION
This PR fixes the Brave Search API implementation to correctly fetch news articles.

## Changes
1. Updated API endpoint from `/news` to `/search`
2. Added correct news search parameters
3. Improved error handling and debugging
4. Added result processing logic

## Code Changes
Please update `daily-brief-bot/src/modules/brave_search.py` with the following content:

```python
import requests
import json

class BraveSearch:
    def __init__(self, api_key):
        self.api_key = api_key
        self.base_url = 'https://api.search.brave.com/v1/search'  # Changed to search endpoint
        self.headers = {
            'Accept': 'application/json',
            'X-Brave-API-Key': api_key  # Using correct header name
        }
    
    def search(self, query, count=5):
        """Search news using Brave Search API"""
        params = {
            'q': query,
            'count': count,
            'type': 'news',  # Specify news search
            'freshness': 'day'  # Get recent news only
        }
        
        try:
            response = requests.get(
                self.base_url,
                headers=self.headers,
                params=params
            )
            
            # Print request details for debugging
            print(f'Request URL: {response.url}')
            print(f'Request headers: {json.dumps(self.headers)}')
            
            response.raise_for_status()
            data = response.json()
            
            # Extract and format news items
            if 'news' in data:
                return data['news']
            elif 'webPages' in data:  # Fallback to web results if no news
                return data['webPages']['value']
            return []
            
        except requests.RequestException as e:
            print(f'Error in Brave Search: {e}')
            if hasattr(e.response, 'text'):
                print(f'Response content: {e.response.text}')
            return []
        except Exception as e:
            print(f'Unexpected error in Brave Search: {e}')
            return []
```

## Testing
After applying these changes:
1. The API will correctly use the news search endpoint
2. Added debugging information will help identify any issues
3. Improved error handling will provide more details about failures
4. Added fallback to web results if no news is found

Please merge this PR and then trigger the GitHub Action to test the changes.