### PR TITLE
fix: update Brave Search API endpoint

### DIFF
--- a/daily-brief-bot/src/modules/brave_search.py
+++ b/daily-brief-bot/src/modules/brave_search.py
@@ -4,7 +4,7 @@ import json
 class BraveSearch:
     def __init__(self, api_key):
         self.api_key = api_key
-        self.base_url = 'https://api.search.brave.com/v1/search'  # Changed to search endpoint
+        self.base_url = 'https://api.search.brave.com/web/search'  # Changed to web/search endpoint
         self.headers = {
             'Accept': 'application/json',
             'X-Brave-API-Key': api_key  # Using correct header name


### PR DESCRIPTION
This PR updates the Brave Search API endpoint to use the correct path.

## Changes
1. Changed API endpoint from `/v1/search` to `/web/search`
2. Maintained existing debug information and error handling

The changes to make in `daily-brief-bot/src/modules/brave_search.py`:

```python
def __init__(self, api_key):
    self.api_key = api_key
    self.base_url = 'https://api.search.brave.com/web/search'  # Changed to web/search endpoint
    self.headers = {
        'Accept': 'application/json',
        'X-Brave-API-Key': api_key
    }
```

## Testing
After applying these changes:
1. The API should correctly connect to the Brave Search endpoint
2. Debug information will help track any remaining issues
3. Error handling remains robust

Please merge this PR and then trigger the GitHub Action to test the changes.