### PR TITLE
修复: 工作流路径问题

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r daily-brief-bot/requirements.txt
+        pip install -r requirements.txt
         
     - name: Run daily brief generator
       env:
@@ -29,5 +29,5 @@ jobs:
         EMAIL_USER: ${{ secrets.EMAIL_USER }}  
         BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
       run: |
-        cd daily-brief-bot/src
+        cd src
         python main.py


### PR DESCRIPTION
此PR修复了工作流文件中的路径问题：

1. 移除了多余的 `daily-brief-bot/` 前缀
2. 简化了目录结构引用

请确保在合并前:
1. 在 GitHub Settings -> Secrets -> Actions 中已设置:
   - EMAIL_PASSWORD
   - EMAIL_USER
   - BRAVE_API_KEY

2. 检查项目根目录结构是否符合:
```
daily-brief-bot/
├── .github/workflows/
│   └── main.yml
├── requirements.txt
└── src/
    └── main.py
```